### PR TITLE
Fix: Audio File Folder loading

### DIFF
--- a/src/lib/store/AppConfig.ts
+++ b/src/lib/store/AppConfig.ts
@@ -1,0 +1,7 @@
+import type { AppConfig } from "$lib/types/AppConfig";
+import { writable } from "svelte/store";
+
+/**
+ * The current state and data view for all config settings around the application.
+ */
+export const ApplicationConfigurationState = writable<AppConfig | null>();

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,6 +1,6 @@
-<script>
-	import config from "$lib/config";
+<script lang="ts">
 	import "../app.css";
+	import config from "$lib/config";
 </script>
 
 <div class="navbar bg-base-100">

--- a/src/routes/config/+page.svelte
+++ b/src/routes/config/+page.svelte
@@ -1,23 +1,20 @@
 <script lang="ts">
 	import { AppConfigLimits, type AppConfig } from "$lib/types/AppConfig";
 	import { onMount, tick } from "svelte";
-	import { writable } from "svelte/store";
 	import { loadAppConfig, resetAppConfig, setAppConfig } from "$lib/utils/tauri";
 	import config from "$lib/config";
- import DevInfo from "$lib/components/popups/dev-info.svelte";
+	import DevInfo from "$lib/components/popups/dev-info.svelte";
+	import { ApplicationConfigurationState } from "$lib/store/AppConfig";
 	// import { getCurrentPlatform, isValidDirectory } from "$lib/utils/format";
-
-	// The updated state of the component
-	const viewState = writable<AppConfig | null>(null);
 
 	// load the current app config when the component is mounted
 	onMount(async () => {
 		const load = await loadAppConfig();
 
 		if (load) {
-			viewState.set(load);
+			ApplicationConfigurationState.set(load);
 		} else {
-			viewState.set(null);
+			ApplicationConfigurationState.set(null);
 		}
 		await tick();
 	});
@@ -26,10 +23,12 @@
 	const runReset = async () => {
 		let result = await resetAppConfig();
 
+		// console.table(result);
+
 		if (result) {
-			viewState.set(result);
+			ApplicationConfigurationState.set(result);
 		} else {
-			viewState.set(null);
+			ApplicationConfigurationState.set(null);
 		}
 		await tick();
 	};
@@ -67,7 +66,7 @@
 			let newData = currentData;
 			// console.table(currentData);
 			await setAppConfig(currentData);
-			viewState.set(newData);
+			ApplicationConfigurationState.set(newData);
 			dirPath = "";
 			await tick();
 		}
@@ -78,7 +77,7 @@
 
 <main>
 	<h1 class="text-2xl mb-6">App Configurations</h1>
-	{#await $viewState}
+	{#await $ApplicationConfigurationState}
 		<p>fetching config file from system...</p>
 	{:then result}
 		{#if result === null}

--- a/src/routes/player/+page.svelte
+++ b/src/routes/player/+page.svelte
@@ -65,7 +65,7 @@
 			if (shouldLoadMp3 === "yes") {
 				const mp3Files = await getAudioFiles(AudioFileType.MP3);
 
-				console.log("MP3", mp3Files);
+				// console.log("MP3", mp3Files);
 
 				for (let i = 0; i < mp3Files.length; i++) {
 					audio_files_arr.push(mp3Files[i]);
@@ -75,7 +75,7 @@
 			if (shouldLoadWav === "yes") {
 				const wavFiles = await getAudioFiles(AudioFileType.WAV);
 
-				console.log("WAV", wavFiles);
+				// console.log("WAV", wavFiles);
 
 				for (let i = 0; i < wavFiles.length; i++) {
 					audio_files_arr.push(wavFiles[i]);


### PR DESCRIPTION
Fix front-end logic. There is a bug where if more than 2 folder paths are selected then only the first folder path will be loaded in the player.